### PR TITLE
Increased z-index of the_top_bar - solving#138

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -290,6 +290,7 @@ html {
   background-color: transparent;
   position: relative;
   display: inline-block;
+  z-index: 999;
 }
 
 /* Dropdown Content (Hidden by Default) */


### PR DESCRIPTION
#138
Dropdown items come forward and rest on top of every other content.

Before:
![image](https://user-images.githubusercontent.com/83979298/214547195-2c9c90c6-fb6b-4502-9680-3408da08c4f2.png)

After:
![image](https://user-images.githubusercontent.com/83979298/214547366-7dea9cf7-4469-4656-8d90-3c4b5fbc5ef2.png)

Note: The "Arts/Icons", "Settings", "Contribute" are just buttons on the navbar and do not have a dropdown. It is better from a UI/UX standpoint to move them to the right for visual separation.